### PR TITLE
Linted markdown files

### DIFF
--- a/doc/client-programming.md
+++ b/doc/client-programming.md
@@ -1,27 +1,25 @@
 # Creating your own client
 
-While dsptoolkit as a command line client works well, you might want to integrate DSP control in your own 
-application. This document describes some use cases and recommendations how to implement these.
+While dsptoolkit as a command line client works well, you might want to integrate DSP control in your own application. This document describes some use cases and recommendations how to implement these.
 
 ## Communication with the DSP
 
 ### dsptoolkit
-The easiest way to communicate with the DSP is using the dsptoolkit as a command line tool. Even if your users don't 
-use it directly, you can call it from your program to communicate with the DSP. While this isn't the most performant 
-way, it integrates a lot of checks that make sure only supported parameters will be updated.
+
+The easiest way to communicate with the DSP is using the dsptoolkit as a command line tool. Even if your users don't use it directly, you can call it from your program to communicate with the DSP. While this isn't the most performant way, it integrates a lot of checks that make sure only supported parameters will be updated.
 
 ### TCP socket
 
 You can directly communicate with the sigmatcpserver processing using TCP. The protocol is used by Analog's SigmaStudio,
 but it was extended by us to support more features.
-There is no authentication supported (as this would break SigmaStudio compatibility). $
+There is no authentication supported (as this would break SigmaStudio compatibility).
 There is no document that describes the protocol in detail. It is recommended, to have a look at the Python source code.
 
 ### SPI
 
-This is the lowest-level approach to communicate with the DSP. It is not recommended for most use cases for the 
-following reasons:
-- If the sigmatcpserver is running, it already blocks acces to SPI
+This is the lowest-level approach to communicate with the DSP. It is not recommended for most use cases for the following reasons:
+
+- If the sigmatcpserver is running, it already blocks access to SPI
 - You need to deal with the internals of the DSP chip
 - There are no high-level functions (e.g. changing the volume), all these have to be implemented again.
 
@@ -29,29 +27,27 @@ following reasons:
 
 HiFiBerry DSP boards can be programmed by the user. While this offers a great flexibility, there are some risks.
 DSP toolkits usually write to a specific memory cell of the DSP to change parameters. The addresses of these cells usually
-depend on the deployed DSP program. Most commercial DSPs use a fixed DSP program that can only be parametrised. 
-This has the advantage that the addresses of all parameters are known and static. The client can just write to a given adress.
+depend on the deployed DSP program. Most commercial DSPs use a fixed DSP program that can only be parametrised.
+This has the advantage that the addresses of all parameters are known and static. The client can just write to a given address.
 
 With the HiFiBerry DSP products, it is a bit more complicated. As the user can change the DSP program at any time, you can't
 be sure that a given DSP program is running. sigmatcpserver and dsptoolkit deal with this using 2 methods:
-1. Checksum
+
+1. Checksum  
    There is checksum for the DSP program running. If the program changes, the checksum will also change
-2. DSP profiles
-   DSP profiles incldue metadata that map specific functions to memory addresses. This allows the client to check what 
-   features are supported by a specific DSP program and look up the memory addresses of these features.
+2. DSP profiles  
+   DSP profiles include metadata that map specific functions to memory addresses. This allows the client to check what features are supported by a specific DSP program and look up the memory addresses of these features.
 
 ## Updating parameter values
 
 To update specific paramaters e.g. filters in a BiQuad filter bank, we recommend the following:
+
 1. Get the checksum from sigmatcpserver and cache it locally
 2. Get the DSP profile from sigmatcperver
-3. Parse the profile and find the memory adresses 
+3. Parse the profile and find the memory addresses
 4. Update the parameter
 
-For live updates of specific parameters (e.g. user directly modifies a parameter using gestures), it is usually not needed 
-to always check the checksum again as this might create some lagging.
+For live updates of specific parameters (e.g. user directly modifies a parameter using gestures), it is usually not needed to always check the checksum again as this might create some lagging.
 However, we recommend getting the checksum again and checking if the users didn't interact with the application for some time.
 
-If you're 100% sure the user won't upload another DSP profile while they're working with your application, you might 
-skip the checksum verification. 
-
+If you're 100% sure the user won't upload another DSP profile while they're working with your application, you might skip the checksum verification.

--- a/doc/crossovers.md
+++ b/doc/crossovers.md
@@ -1,21 +1,19 @@
 # Creating speaker crossovers with dsptoolkit
 
-While you can always use SigmaStudio to design your individual DSP 
-program for HiFiBerry DSP boards, for simple use cases, this might be
-overkill. 
+While you can always use SigmaStudio to design your individual DSP program for HiFiBerry DSP boards, for simple use cases, this might be overkill.
 
-Therefore, we provide a simple way to create your own n-way crossovers
-using a configuration file
+Therefore, we provide a simple way to create your own n-way crossovers using a configuration file
 
 ## What you need
 
 ### DSP toolkit
+
 First you need to have the DSP toolkit in at least version 0.10 installed.
 Get it at https://github.com/hifiberry/hifiberry-dsp
 
 ### A DSP profile that supports a mixing/crossover matrix
-A mixing/crossover matrix allows you to mix each input channel onto 
-each output channel and also apply filtering.
+
+A mixing/crossover matrix allows you to mix each input channel onto each output channel and also apply filtering.
 In SigmaStudio it looks like this:
 
 ![crossover matrix](img/crossover-matrix.png)
@@ -26,23 +24,20 @@ https://raw.githubusercontent.com/hifiberry/hifiberry-dsp/master/sample_files/xm
 ## Installing the DSP profile
 
 First, you need to install the profile onto the DSP:
-```
+
+```bash
 dsptoolkit install-profile 4way-iir.xml
 ```
 
-You don't even have to download the profile by yourself as dsptoolkit 
-directly accepts URLs:
+You don't even have to download the profile by yourself as dsptoolkit directly accepts URLs:
 
-```
+```bash
 dsptoolkit install-profile https://raw.githubusercontent.com/hifiberry/hifiberry-dsp/master/sample_files/xml/4way-iir.xml
 ```
 
-
-
 ## Create a crossover settings file
 
-The settings files defines the filters used on each channel of the 
-mixing/crossover matrix
+The settings files defines the filters used on each channel of the mixing/crossover matrix
 
 A very simply example looks like this:
 
@@ -58,20 +53,17 @@ IIR_R4: mute
 ```
 
 This settings will pass the left channel to output 1 of the DSP board
-and the right channel to output 2 without any processing. This is 
-basically a normal stereo fullrange configuration.
+and the right channel to output 2 without any processing. This is basically a normal stereo full range configuration.
 
-For a crossover, you need to use low-pass and high-pass filters. Let's 
-do a simple 2 way setup with a crossover at 2kHz.
+For a crossover, you need to use low-pass and high-pass filters. Let's do a simple 2 way setup with a crossover at 2kHz.
 The connection to the DSP board is as follows:
+
 - woofer left:   channel 1
 - woofer right:  channel 2
 - tweeter left:  channel 3
 - tweeter right: channel 4
 
-On the Beocreate 4 channel amplifier it is recommended to connect woofers
-to channels 1 and 2 as these can provide twice the power of channels 
-3 and 4
+On the Beocreate 4 channel amplifier it is recommended to connect woofers to channels 1 and 2 as these can provide twice the power of channels 3 and 4
 
 ```
 IIR_L1: lp:2000Hz
@@ -84,33 +76,28 @@ IIR_R3: mute
 IIR_R4: hp: 2000Hz
 ```
 
-With this settings configuration, 
-* output 1 receives a signal from the left channel filtered with a 2kHz low-pass filter
-* output 2 receives a signal from the right channel filtered with a 2kHz low-pass filter
-* output 3 receives a signal from the left channel filtered with a 2kHz high-pass filter
-* output 4 receives a signal from the right channel filtered with a 2kHz high-pass filter
+With this settings configuration,
+
+- output 1 receives a signal from the left channel filtered with a 2kHz low-pass filter
+- output 2 receives a signal from the right channel filtered with a 2kHz low-pass filter
+- output 3 receives a signal from the left channel filtered with a 2kHz high-pass filter
+- output 4 receives a signal from the right channel filtered with a 2kHz high-pass filter
 
 ## Applying the crossover
 
-Save you crossover file as a file, e.g. crossover.txt. Then use 
-dsptoolkit to apply the settings on the DSP
+Save you crossover file as a file, e.g. crossover.txt. Then use dsptoolkit to apply the settings on the DSP.
 
-```
+```bash
 dsptoolkit apply-settings crossover.txt
 ```
 
-This will apply the settings just in the DSP RAM, not store them 
-permanently. This is recommended especially when you develop crossovers
-as it is the fastest way to apply settings and fix potential problems.
+This will apply the settings just in the DSP RAM, not store them permanently. This is recommended especially when you develop crossovers as it is the fastest way to apply settings and fix potential problems.
 Sometimes things can go wrong, e.g. if you have mixed up channels.
 In this case, just edit the file and apply the settings again.
 
-In rare cases it can happen that something is completely wrong and you
-fear that your speakers might be damaged (e.g. if you have accidentelly 
-applied a huge volume increase). In these cases, the fastest way to 
-return to the default settings is to reset the DSP:
+In rare cases it can happen that something is completely wrong and you fear that your speakers might be damaged (e.g. if you have accidentally applied a huge volume increase). In these cases, the fastest way to return to the default settings is to reset the DSP:
 
-```
+```bash
 dsptoolkit reset
 ```
 
@@ -118,10 +105,8 @@ This will load the standard settings from the DSP's EEPROM.
 
 ## Optimizing the crossover
 
-In most cases a crossover like this won't work perfectly as this would
-only be correct if woofers and tweeters have exactly the same efficiency.
-Usually the tweeters will be some decibels too loud. You can correct 
-this with an additional "vol" filter:
+In most cases a crossover like this won't work perfectly as this would only be correct if woofers and tweeters have exactly the same efficiency.
+Usually the tweeters will be some decibels too loud. You can correct this with an additional "vol" filter:
 
 ```
 IIR_L1: lp:2000Hz
@@ -134,7 +119,7 @@ IIR_R3: mute
 IIR_R4: hp: 2000Hz, vol:-3dB
 ```
 
-This would reduce the volume of the tweeters by 3dB
+This would reduce the volume of the tweeters by 3dB.
 
 ## Further optimizations
 
@@ -142,71 +127,56 @@ There are a lot more optimisations you can do here:
 
 ### Adding a subsonic filter
 
-Filtering low frequencies that the speaker can't really handle is 
-often a good idea:
+Filtering low frequencies that the speaker can't really handle is often a good idea:
+
 ```
 IIR_L1: lp:2000Hz,hp:30Hz,hp:30Hz
 ```
-This adds a 4th order high-pass filter to the woofer channel that 
-removes very low frequencies. Depending on your speaker a value 
-between 20 and 100Hz might be used
+
+This adds a 4th order high-pass filter to the woofer channel that removes very low frequencies. Depending on your speaker a value between 20 and 100Hz might be used
 
 ### Filtering specific frequencies
 
 The frequency response of almost any loudspeakers isn't really flat.
-So you might add some filters to increase or decrease the volume at 
-a specific frequency:
+So you might add some filters to increase or decrease the volume at a specific frequency:
 
 ```
 IIR_R4: hp: 2000Hz, vol:-3dB, eq:5000Hz:2:+2dB
 ```
 
-Note that you will need measurement equipment to correctly design these
-filters.
+Note that you will need measurement equipment to correctly design these filters.
 
-### Delays for specific channels 
+### Delays for specific channels
 
-It might be necessary to delay a channel a bit (often the tweeter). If the profile
-supports delays, you can configure them also with settings:
+It might be necessary to delay a channel a bit (often the tweeter). If the profile supports delays, you can configure them also with settings:
 
 ```
 delay1: 100
 ```
 
-Note that the delay is defined in samples. At 48kHz the lengths of a sample is roughly 
-0.02ms. So a delay 100 means approximately 2ms delay. If your profile is using a 
-different sample rate, you need to do the calculations according to your sample rate
-(which is the internal DSP sample rate, NOT the sample rate of music you want to  
-play back).
+Note that the delay is defined in samples. At 48kHz the lengths of a sample is roughly 0.02ms. So a delay 100 means approximately 2ms delay. If your profile is using a different sample rate, you need to do the calculations according to your sample rate (which is the internal DSP sample rate, NOT the sample rate of music you want to play back).
 
 ## Write the settings to the EEPROM
 
-If your crossover is working as expected, you should save it to the 
-EEPROM of the DSP board. This ensures that the crossover is still 
-correctly configured after a reboot.
+If your crossover is working as expected, you should save it to the EEPROM of the DSP board. This ensures that the crossover is still correctly configured after a reboot.
 
-```
+```bash
 dsptoolkit store-settings crossover.txt
 ```
 
 Check if is stored correctly by resetting the DSP:
 
-```
+```bash
 dsptoolkit reset
 ```
 
-
 ## Merge the settings into an existing DSP profile
 
-If you want to share your settings or apply the profile including these
-settings on another system, it can help to merge the settings into
-an existing XML DSP profile. 
-This can also be done with dsptoolkit by just adding the file name of 
-the XML profile file:
+If you want to share your settings or apply the profile including these settings on another system, it can help to merge the settings into an existing XML DSP profile.
+This can also be done with dsptoolkit by just adding the file name of the XML profile file:
 
-```
+```bash
 dsptoolkit store-settings crossover.txt profile.xml
 ```
 
-Note that this will NOT apply the settings directly to the DSP, but 
-only to the XML profile file.
+Note that this will NOT apply the settings directly to the DSP, but only to the XML profile file.

--- a/doc/dspprofiles.md
+++ b/doc/dspprofiles.md
@@ -1,23 +1,16 @@
 # DSP Profiles
 
-Our DSP toolskit uses so-called DSP profiles to describe the DSP 
-program. They basically consist of a collection of instructions that
-write a DSP program to the DSP.
+Our DSP toolkit uses so-called DSP profiles to describe the DSP program. They basically consist of a collection of instructions that write a DSP program to the DSP.
 
-The process to create these profiles consists of multiple steps that
-are described here.
+The process to create these profiles consists of multiple steps that are described here.
 
 ## Create the DSP program
 
-Firs you have to create you DSP program in SigmaStudio. You can use
-all available controls and functions.
+Firs you have to create you DSP program in SigmaStudio. You can use all available controls and functions.
 
-However, it is recommended to use an existing project and adapt it
-to your needs. This is usually much easier than creating a new DSP
-program from scratch.
+However, it is recommended to use an existing project and adapt it to your needs. This is usually much easier than creating a new DSP program from scratch.
 
-There are some specific functions that can be controlled later by 
-dsptoolkit:
+There are some specific functions that can be controlled later by dsptoolkit:
 
 - Volume - controls the output volume
 - VolumeLimit - controls the maximum volume
@@ -25,114 +18,92 @@ dsptoolkit:
 - Mute - a switch to mute the output
 - IIR_L, IIR_R - 2 IIR filter banks to apply equalisations to left and
  right channels
-- IIR_L1,IIR_L2,IIR_L3,IIR_L4, IIR_R1,IIR_R2,IIR_R3,IIR_R4 - 
-  a mixer/equalisation matrix to implement crossovers
-- Delay1 - Delay9
-  up to 9 delays for individual channels
+- IIR_L1,IIR_L2,IIR_L3,IIR_L4, IIR_R1,IIR_R2,IIR_R3,IIR_R4 - a mixer/equalisation matrix to implement crossovers
+- Delay1 - Delay9 - up to 9 delays for individual channels
   ![crossover matrix](img/crossover-matrix.png)
 
-  
-It is recommended to implement at least the Volume and VolumeLimit 
-controls. 
+It is recommended to implement at least the Volume and VolumeLimit controls.
 
 Feel free to add more controls to the DSP programs.
 
 ## Write the program to the DSP
 
-Select the Hardware configuration tab on top and config tab on the 
-bottom and you should see a TCP control. Right click onto it to change
-the TCP/IP settings
+Select the Hardware configuration tab on top and config tab on the bottom and you should see a TCP control. Right click onto it to change the TCP/IP settings.
 
 ![SigmaStudio TCP/IP](img/ss-tcpip.png)
 
-Enter the IP address of your system here, click "Open connection" and 
-close the settings again.
+Enter the IP address of your system here, click "Open connection" and close the settings again.
 
-Now select "Action/Link Compile Download" in the menu. This will push 
-the DSP program onto the DSP.
+Now select "Action/Link Compile Download" in the menu. This will push the DSP program onto the DSP.
 
-You can now test your program and check if everything performs as 
-expected.
+You can now test your program and check if everything performs as expected.
 
 ## Write the program to the EEPROM
 
-Until now, the program only resides in the DSP memory. It will be 
-deleted of you reset the DSP (e.g. on power loss). Therefore, you should 
-write it to the EEPROM. You can also use this step already to create 
-a DSP profile.
+Until now, the program only resides in the DSP memory. It will be deleted of you reset the DSP (e.g. on power loss). Therefore, you should write it to the EEPROM. You can also use this step already to create a DSP profile.
 
 First open a capture window using the "View/Capture window menu".
-You should now see an additional "Capture window". This will record all
-transactions send to the DSP.
+You should now see an additional "Capture window". This will record all transactions send to the DSP.
 
 ![SigmaStudio Capture window](img/ss-capture.png)
   
-The capture window should be empty. If it isn't click on the 
-"Clear all output data" button in the top-left of this window.
+The capture window should be empty. If it isn't click on the "Clear all output data" button in the top-left of this window.
 
-Right-click onto the ADAU1451 and select 
-"Write latest compilation through DSP"
+Right-click onto the ADAU1451 and select "Write latest compilation through DSP".
 
 ![SigmaStudio Write EEPROM](img/ss-write-eeprom.png)
 
-Configure the properties as follows and click "OK"
+Configure the properties as follows and click "OK".
 
 ![SigmaStudio EEPROM settings](img/ss-eeprom-settings.png)
 
 This will take some time and you should now see the transactions in the
 capture window.
 
-## Export the DSP profile 
+## Export the DSP profile
 
 Now mark all transactions in the capture window and right click on
 "Add to sequence"
 
 ![SigmaStudio Add to sequence](img/ss-add-sequence.png)
   
-A new subwindow should open with the recorded transactions. Use the 
-save button in this window to export the sequence file. 
+A new subwindow should open with the recorded transactions. Use the save button in this window to export the sequence file.
 
 You now have created an XML file that can be used as a DSP profile.
 
-It can be downloaded using dsptoolkit
+It can be downloaded using dsptoolkit.
 
-```
+```bash
 dsptoolkit install-profile filename
 ```
- 
+
 ## Metadata
 
-While the program can be already written to the DSP, you can't control 
-any settings directly from dsptoolkit. The reason is simple: dsptoolkit
-don't have any information about this program except the program itself. 
-It doesn't know what controls are implemented and how they can be 
-controlled. 
+While the program can be already written to the DSP, you can't control any settings directly from dsptoolkit. The reason is simple: dsptoolkit doesn't have any information about this program except the program itself.
+It doesn't know what controls are implemented and how they can be controlled.
 To support this, you have to add metadata to the DSP profile.
 
-The first step is to export more data from SigmaStudio. Select 
-"Export system files" from the action menu.
+The first step is to export more data from SigmaStudio. Select "Export system files" from the action menu.
 
 ![SigmaStudio Export system files](img/ss-export-system.png)
 
-This will create a lot of files. 
-Note if you used the project filename also for the XML file, exporting 
-the system files will overwrite this file, as it will also create a 
-projectname.xml that will overwrite the profile that you've just created.
+This will create a lot of files.
+Note if you used the project filename also for the XML file, exporting the system files will overwrite this file, as it will also create a projectname.xml that will overwrite the profile that you've just created.
 Therefore you should rename the profile file before exporting the system
 files.
 
-The only file that is really needed for the metadata is 
-the .params file. This file contains a description of all controls,
+The only file that is really needed for the metadata is the .params file. This file contains a description of all controls,
 their addresses in memory and their settings.
 
 It looks like this (but much longer)
+
 ```
 Cell Name         = SPDIF output.Nx2-2
 Parameter Name    = stereomuxSigma300ns2index
 Parameter Address = 547
 Parameter Value   = 0
 Parameter Data :
-0x00, 0x00, 0x00, 0x00, 
+0x00, 0x00, 0x00, 0x00,
 
 
 
@@ -141,7 +112,7 @@ Parameter Name    = DCInpAlg145X1value
 Parameter Address = 525
 Parameter Value   = 1
 Parameter Data :
-0x01, 0x00, 0x00, 0x00, 
+0x01, 0x00, 0x00, 0x00,
 
 
 
@@ -150,7 +121,7 @@ Parameter Name    = DCInpAlg145X2value
 Parameter Address = 526
 Parameter Value   = 2
 Parameter Data :
-0x02, 0x00, 0x00, 0x00, 
+0x02, 0x00, 0x00, 0x00,
 
 
 
@@ -159,35 +130,27 @@ Parameter Name    = SwitchAlg321ison
 Parameter Address = 527
 Parameter Value   = 0
 Parameter Data :
-0x00, 0x00, 0x00, 0x00, 
+0x00, 0x00, 0x00, 0x00,
 ```
 
-Based on these information you could create the metadata records 
-by yourself.
+Based on these information you could create the metadata records by yourself.
 
 A  metadata record is basically a name with an associated address
-```
+
+```xml
 <metadata type="balanceRegister">525</metadata>
 ```
 
-This declares that the balance setting is stored at the memory address
-525. You also see this address in the parameters file.
+This declares that the balance setting is stored at the memory address 525. You also see this address in the parameters file.
 
-These memory locations are not static and they will change if you modify
-your DSP program. This means the process of creating metadata has to be
-repeated each time you add or remove controls in your DSP program or
-change connection between function blocks.
+These memory locations are not static and they will change if you modify your DSP program. This means the process of creating metadata has to be repeated each time you add or remove controls in your DSP program or change connection between function blocks.
 
-As the process of creating metadata records takes quite a lot of time, 
-there is a tool that can automatically create the metadata. The tool has
-the name "mergeparameters". It accepts the XML file and params file as
-command line argument. 
+As the process of creating metadata records takes quite a lot of time, there is a tool that can automatically create the metadata. The tool has the name "mergeparameters". It accepts the XML file and params file as command line argument.
 
-It will read known parameter names from the params file and add the
-metadata records to the DSP program:
+It will read known parameter names from the params file and add the metadata records to the DSP program:
 
-```
-mergeparameters 4way-iir.xml 4way-iir.params 
+```bash
+mergeparameters 4way-iir.xml 4way-iir.params
 added parameters to XML profile:
   IIR_L
   IIR_L1
@@ -204,22 +167,14 @@ added parameters to XML profile:
   muteRegister
   volumeControlRegister
   volumeLimitRegister
-````
-
-One metadata record that isn't generated is the checksum. It is used 
-to identify a program. While it is optional, it is **strongly recommended**
-to add a checksum. To calculate the checksum, push the DSP profile to 
-the dsp and then use the "get-checksum" command.
-
-Why is it important to have the checksum? If you're experimenting with
-different profile, there might be a situation where the DSP server thinks
-a specific program is installed, but there is really another program 
-running on the DSP. 
-Changing settings based on the wrong profile might result in all kinds
-of unwanted behaviour. In worst case the DSP program might generate a 
-high-level output signal that can damage your speakers.
-
 ```
+
+One metadata record that isn't generated is the checksum. It is used to identify a program. While it is optional, it is **strongly recommended** to add a checksum. To calculate the checksum, push the DSP profile to the dsp and then use the "get-checksum" command.
+
+Why is it important to have the checksum? If you're experimenting with different profile, there might be a situation where the DSP server thinks a specific program is installed, but there is really another program running on the DSP.
+Changing settings based on the wrong profile might result in all kinds of unwanted behavior. In worst case the DSP program might generate a high-level output signal that can damage your speakers.
+
+```bash
 dsptoolkit install-profile 4way-iir.xml
 dsptoolkit get-checksum
  8B924F2C2210B903CB4226C12C56EE44
@@ -227,12 +182,12 @@ dsptoolkit get-checksum
 
 Now add a metadata record to the XML profile
 
-```
+```xml
 <metadata type="checksum">8B924F2C2210B903CB4226C12C56EE44</metadata>
 ```
 
 Push the profile to the DSP again
 
-```
+```bash
 dsptoolkit install-profile 4way-iir.xml
 ```

--- a/doc/dsptoolkit.md
+++ b/doc/dsptoolkit.md
@@ -1,149 +1,112 @@
 Command line utility
 ====================
 
-dsptoolkit is a tool that is used to directly access functions of the DSP 
-via the TCP server. This means it can run on another system.
+dsptoolkit is a tool that is used to directly access functions of the DSP via the TCP server. This means it can run on another system.
 
 The general usage pattern is
 
-$ dsptoolkit command parameter
+```bash
+dsptoolkit command parameter
+```
 
-The following command are supported. Note that some command need specific 
-parameters in the DSP profile. If the DSP profile does not support these,
-the command won't have any effect.
+The following commands are supported. Note that some command need specific parameters in the DSP profile. If the DSP profile does not support these, the command won't have any effect.
 
-* install-profile
+* `install-profile`
 
-  writes a DSP profile to the DSP EEPROM and activates it. A profile 
-  installed with this command will be automatically started after a reset
+  writes a DSP profile to the DSP EEPROM and activates it. A profile installed with this command will be automatically started after a reset.
   
-* set-volume volume
+* `set-volume volume`
 
-  set the volume. Volume values can be defined in real values (0-1), 
-  percent (0% to 100%) or decibels (you need to use negative values to 
-  reduce the volume)
-  For negative db values, you need to prefix these with --, e.g.
-    dsptoolkit set-volume -- -3db
+  set the volume. Volume values can be defined in real values (0-1), percent (0% to 100%) or decibels (you need to use negative values to reduce the volume)
+  For negative db values, you need to prefix these with `--`, e.g.  
+    `dsptoolkit set-volume -- -3db`
 
-* get-volume
+* `get-volume`
 
-  gets the current setting of the volume control register. 
+  gets the current setting of the volume control register.
 
-* set-limit
+* `set-limit`
 
-  sets the volume limit. The effect is the same as setting volume. The 
-  idea of this setting is having a volume control that can be changed 
-  between 0 and 100% (or -inf dB to 0dB) and the limit setting to set 
-  the maximum volume of the system.
-  For negative db values, you need to prefix these with --, e.g.
-    dsptoolkit set-limit -- -3db
+  sets the volume limit. The effect is the same as setting volume. The idea of this setting is having a volume control that can be changed between 0 and 100% (or -inf dB to 0dB) and the limit setting to set the maximum volume of the system.
+  For negative db values, you need to prefix these with `--`, e.g.  
+    `dsptoolkit set-limit -- -3db`
 
-* set-rew-filters|set-rew-filters-left|set-rew-filters-right filename
+* `set-rew-filters|set-rew-filters-left|set-rew-filters-right filename`
 
-  Deploys parametric equaliser settings calculated by REW to the 
-  equaliser filter banks (left, right or both).
-  Not all DSP profiles will support this setting
-  To make sure the filters are still active after a system reboot, make 
-  sure you use the store command.
+  Deploys parametric equaliser settings calculated by REW to the equaliser filter banks (left, right or both).
+  Not all DSP profiles will support this setting.
+  To make sure the filters are still active after a system reboot, make sure you use the store command.
 
-* set-fir-filters|set-fir-filters-left|set-fir-filters-right
+* `set-fir-filters|set-fir-filters-left|set-fir-filters-right`
 
-  Deploys a FIR (finite impulse response) filter to the left, right or 
-  both FIR filter banks.
+  Deploys a FIR (finite impulse response) filter to the left, right or both FIR filter banks.
   A FIR filter file is a simple text file with one real number per line.
-  Not all DSP profiles will support this setting
-  To make sure the filters are still active after a system reboot, make 
-  sure you use the store command.
+  Not all DSP profiles will support this setting.
+  To make sure the filters are still active after a system reboot, make sure you use the store command.
 
-* clear-iir-filters
+* `clear-iir-filters`
 
-  Resets the IIR filter banks to default values. This is helpful if you 
-  deployed filters to the DSP that do not perform as expected
+  Resets the IIR filter banks to default values. This is helpful if you deployed filters to the DSP that do not perform as expected
 
-* read-dec|red-int|read-hex address
+* `read-dec|red-int|read-hex address`
 
-  Reads a memory word from the given address and interprets it as a 
-  decimal value, integer value or just displays it as a HEX value
-  Addresses are 2byte long and they can be defined as integers or hex 
-  values.
-  Hex values are defined by the prefix 0x (e.g. 0x01aa)
+  Reads a memory word from the given address and interprets it as a decimal value, integer value or just displays it as a HEX value.
+  Addresses are 2byte long and they can be defined as integers or hex values.
+  Hex values are defined by the prefix `0x` (e.g. `0x01aa`)
 
-* loop-read-dec|loop-read-int|loop-read-hex address
+* `loop-read-dec|loop-read-int|loop-read-hex address`
   
-  Works exactly like the read-xxx command. However, it reads the values 
-  in a loop. This is often useful when debugging DSP programs as you can 
-  easily see if and how parameters change
+  Works exactly like the read-xxx command. However, it reads the values in a loop. This is often useful when debugging DSP programs as you can easily see if and how parameters change
 
-* write-reg address value
+* `write-reg address value`
 
-  Writes a value to a 2-byte register. This command should be used to 
-  write the DSP register addresses. While it will also accept DSP RAM 
-  addresses, these are 4 bytes long and the command will only set the 
-  first 2 bytes of a RAM cell
+  Writes a value to a 2-byte register. This command should be used to write the DSP register addresses. While it will also accept DSP RAM addresses, these are 4 bytes long and the command will only set the first 2 bytes of a RAM cell.
 
-* write-mem address value
+* `write-mem address value`
 
   Writes a 4 byte value to a memory cell.
-  The value can be given as an integer or hex value. 
-  When using this command on register addresses, the command will write 
-  to 2 consecutive register addresses as addresses have a length of 
-  only 2 bytes.
+  The value can be given as an integer or hex value.
+  When using this command on register addresses, the command will write to 2 consecutive register addresses as addresses have a length of only 2 bytes.
   
-* mute|unmute
- 
-  Mutes/unmutes the output. This only works if the profile supports
-  a mute register
+* `mute|unmute`
 
-* servers
+  Mutes/unmutes the output. This only works if the profile supports a mute register.
 
-  Find all servers on the local network using Zeroconf
+* `servers`
+
+  Find all servers on the local network using Zeroconf.
   
-* apply-settings settings-file
+* `apply-settings settings-file`
 
-  Apply the parameter settings from the given parameter file to the 
-  running program. 
+  Apply the parameter settings from the given parameter file to the running program.
   
-* store-settings settings-file [xml-file]
+* `store-settings settings-file [xml-file]`
 
-  Apply the parameter from the given parameter file to the 
-  running program. Also store them into the given DSP profile. 
-  This means, the deault settings of this DSP Profile will be changed.
+  Apply the parameter from the given parameter file to the running program. Also store them into the given DSP profile.
+  This means, the default settings of this DSP Profile will be changed.
   There are 2 possible ways to merge this into a DSP profile:
-  1. If an XML file is given in the command line, the settings will be
-     applied to this DSP profile. The profile file will be edited. 
-     A backup version of teh DSP profile will be stored
-  2. If no xml-file parameter is given, dnstoolkit retrieves the 
-     currently running DSP program directly from the server, applies
-     the settings and pushed the profile back to the server. In this
-     case, the server not only activated this, but also stores the
-     changed settings to the EEPROM. They will then be automatically
-     activated after a reset of the DSP board.     
+  1. If an XML file is given in the command line, the settings will be applied to this DSP profile. The profile file will be edited.  
+     A backup version of teh DSP profile will be stored.
+  2. If no xml-file parameter is given, dsptoolkit retrieves the currently running DSP program directly from the server, applies the settings and pushed the profile back to the server. In this case, the server not only activated this, but also stores the changed settings to the EEPROM. They will then be automatically activated after a reset of the DSP board.
 
-* save
+* `save`
 
-  saves the current parameter RAM to the file system. This is recommended 
-  if you have deployed new filters or changed other settings that 
-  should be re-activated later
-  This does NOT save anything to EEPROM
+  saves the current parameter RAM to the file system. This is recommended if you have deployed new filters or changed other settings that should be re-activated later.  
+  This does NOT save anything to EEPROM.
 
-* load
+* `load`
 
-  restores the parameter RAM from the file system
+  restores the parameter RAM from the file system.
 
-* store-filters
+* `store-filters`
 
-  Store filters currently deployed in the IIR and FIR filter banks to 
-  the EEPROM
+  Store filters currently deployed in the IIR and FIR filter banks to the EEPROM.
   
-* store
+* `store`
 
-  Store all known paramater settings (filters, volume, balance) that
-  are currently active on the DSP to the DSP's EEPROM.
-  Reseting the EEPROM will than recover these settings
+  Store all known parameter settings (filters, volume, balance) that are currently active on the DSP to the DSP's EEPROM.
+  Resetting the EEPROM will than recover these settings.
   
+* `reset`
 
-* reset
-
-  Resets the DSP. The program will be loaded from the EEPROM. The 
-  parameter RAM won't be stored and/or recovered from the file system.
-
+  Resets the DSP. The program will be loaded from the EEPROM. The parameter RAM won't be stored and/or recovered from the file system.

--- a/doc/iirfilters.md
+++ b/doc/iirfilters.md
@@ -1,40 +1,36 @@
 IIR filter format
 =================
 
-Standard IIR filters like high-pass, low-pass, bandpass and parametric 
-equalisers can be described by a simple text syntax. This allows to 
-create these filters from a textual respresentation that can be edited 
-easyly without the need to use SigmaStudio to to filter adjustments 
+Standard IIR filters like high-pass, low-pass, bandpass and parametric equalisers can be described by a simple text syntax. This allows to create these filters from a textual representation that can be edited easily without the need to use SigmaStudio to to filter adjustments.
 
-* lp:frequency:q
+* `lp:frequency:q`  
   defines a second-order low-pass filter with the given corner frequency
   and quality. If quality isn't given, 0.707 is used (Butterworth filter)
-* hp:frequency:q
+* `hp:frequency:q`  
   defines a second-order high-pass filter with the given corner frequency
   and quality. If quality isn't given, 0.707 is used (Butterworth filter)
-* eq:frequency:q:gain
+* `eq:frequency:q:gain`  
   defines a parametric equaliser with the given center frequency
   and quality. gain (in decibel) can be positive or negative
-* coeff:a0:a1:a2:b0:b1:b2 or coeff:a1:a2:b0:b1:b2
+* `coeff:a0:a1:a2:b0:b1:b2` or `coeff:a1:a2:b0:b1:b2`  
   defines a biquad filter with the given filter coefficients. If a0 is
-  not given (only 5 parameters) it is assumed to be 1 (this is the 
-  normalized representation used by the DSP internally)
-* pass
+  not given (only 5 parameters) it is assumed to be 1 (this is the normalized representation used by the DSP internally)
+* `pass`  
   defines a filter that just passes the signal without any modifications
-* mute
+* `mute`  
   defines a filter that completely mutes the signal
-* vol:xdb
+* `vol:xdb`  
   defines a filter that changes the volume by x decibel. x can be
   positive (increases volume) or negative (reduces volume)
   
-Often IIR filters can be chained to define more complex filters. To chain 
-filters, just create a filter list of multiple filters seperated by ",",
-e.g.
+Often IIR filters can be chained to define more complex filters. To chain filters, just create a filter list of multiple filters separated by ",", e.g.
 
+```
 lp:1500Hz, lp:1500Hz, hp:300Hz:0.6, eq:1200Hz:2:+3dB
+```
 
 This defines a filter that consists of:
- - a 4th order low-pass at 1.5kHz (created from two 2nd order filters)
- - a 2nd order high-pass as 300Hz with a quality of 0.6
- - a parametric equaliser at 1.2kHz with a quality of 2.0 and +3dB gain  
 
+* a 4th order low-pass at 1.5kHz (created from two 2nd order filters)
+* a 2nd order high-pass as 300Hz with a quality of 0.6
+* a parametric equaliser at 1.2kHz with a quality of 2.0 and +3dB gain  

--- a/doc/remote-servers.md
+++ b/doc/remote-servers.md
@@ -1,12 +1,11 @@
 Controlling remote servers
 ==========================
 
-The dsptoolkit client tool can not just be used with a local server, but also with other systems 
-on the network. It uses port TCP port 8089 to communicate with local and remote instances.
+The dsptoolkit client tool can not just be used with a local server, but also with other systems on the network. It uses port TCP port 8089 to communicate with local and remote instances.
 
 You can list instances running on the local network:
 
-```
+```console
 dsptoolkit servers
 Looking for devices
 raspberrypi._sigmatcp._tcp.local.: 192.168.99.7:8086 (version 0.11)
@@ -14,7 +13,7 @@ raspberrypi._sigmatcp._tcp.local.: 192.168.99.7:8086 (version 0.11)
 
 To control a remote server, just use the "--host" command line argument:
 
-```
+```console
 dsptoolkit --host 192.168.99.7 get-volume
 Volume: 1.0000 / 100% / 0db
 

--- a/doc/reverse-engineering-lg.md
+++ b/doc/reverse-engineering-lg.md
@@ -1,16 +1,12 @@
 # Reverse engineering LG SoundSync
 
-LG TVs have a feature calles "SoundSync (optical)" that allows the TV to control the
-volume of a sound bar or speaker that is connected via SPDIF.
+LG TVs have a feature called "SoundSync (optical)" that allows the TV to control the volume of a sound bar or speaker that is connected via SPDIF.
 As this might be useful, let's see if we can find out how this works.
 
 ## Basics
 
 SPDIF is a one-way protocol. There is no feedback from the receiver to the sender.
-Therefore no negotiation between sender and receiver is possible. SPDIF sends a 
-left/right data stream. In addition to the PCM data, additional status and user bits
-can be set. Unfortunately there is no common standard to encode control information 
-into these bits.
+Therefore no negotiation between sender and receiver is possible. SPDIF sends a left/right data stream. In addition to the PCM data, additional status and user bits can be set. Unfortunately there is no common standard to encode control information into these bits.
 
 I would expected that LG uses some of these bits to send additional control information.
 Let's have a look.
@@ -93,9 +89,7 @@ Looks like this changes some status bits - cool :-)
 
 ## Conclusions
 
-It seems the volume information is encoded multiple times. It might be the 
-easiest way to use Bytes 16/17 and map the range 0x100f - 0x164F to the volume
-range 0-100%.
+It seems the volume information is encoded multiple times. It might be the easiest way to use Bytes 16/17 and map the range 0x100f - 0x164F to the volume range 0-100%.
 
 This gives the simple formula:
 

--- a/doc/rew-basics.md
+++ b/doc/rew-basics.md
@@ -1,26 +1,16 @@
-# Optimizing accoustics performance with DSPToolkit and REW
+# Optimizing acoustics performance with DSPToolkit and REW
 
-While many people try improving the performance of their audio systems 
-with higher-quality components, there is one component that most people 
-miss: the listening room.
+While many people try improving the performance of their audio systems with higher-quality components, there is one component that most people miss: the listening room.
 
-Normal listening rooms at home are rarely optimised for best sound 
-reproduction. The best way would be to really optimise room acoustics. 
-However, this often doesn't work well as it would mean adding a lot of 
-absorbers and diffusors to your listening room. The worst thing about 
-it: To perform well at low frequencies, these devices have 
-to be very large.
+Normal listening rooms at home are rarely optimised for best sound reproduction. The best way would be to really optimise room acoustics.
+However, this often doesn't work well as it would mean adding a lot of absorbers and diffusors to your listening room. The worst thing about it: To perform well at low frequencies, these devices have to be very large.
 
-But there's another way to deal with problems in room acoustics - 
-corrections using specifically designed electronic filters. This won't 
-be a full replacement for optimised room acoustics, but it will 
-definitely improve the performance of you audio system.
+But there's another way to deal with problems in room acoustics - corrections using specifically designed electronic filters. This won't be a full replacement for optimised room acoustics, but it will definitely improve the performance of you audio system.
 
 ## What do you need?
 
 * Raspberry Pi
-* DSP equipped HiFiBerry board - the DAC+ DSP or the 
-  Beocreate 4 channel amplifier
+* DSP equipped HiFiBerry board - the DAC+ DSP or the Beocreate 4 channel amplifier
 * a measurement microphone
 * a PC with an SPDIF output
 * [REW](https://www.roomeqwizard.com/)
@@ -28,86 +18,70 @@ definitely improve the performance of you audio system.
 
 ![equipment](img/roomeq-equipment.jpg)
 
-While REW can run directly on the Raspberry Pi, we don't recommend it. 
-The Raspberry Pi is quite slow for this kinds of software which makes 
-the usability quite bad.
+While REW can run directly on the Raspberry Pi, we don't recommend it. The Raspberry Pi is quite slow for this kinds of software which makes the usability quite bad.
 
 ## Sound card configuration
 
-For this guide, we assume that your HiFiBerry sound card is already 
-configured correctly. If you need more information how to do this,
-have a look at www.hifiberry.com
+For this guide, we assume that your HiFiBerry sound card is already configured correctly. If you need more information how to do this, have a look at www.hifiberry.com
 
 ## Software installation
 
-If the DSP toolkit isn't already installed, you can install it with 
-a simple script:
+If the DSP toolkit isn't already installed, you can install it with a simple script:
 
+```bash
 bash <(curl https://raw.githubusercontent.com/hifiberry/hifiberry-dsp/master/install-dsptoolkit)
-Check if it is installed correctly by running "dsptoolkit"
 ```
+
+Check if it is installed correctly by running "dsptoolkit"
+
+```bash
 dsptoolkit
 ```
 
 ## Install the DSP program
 
-Install a DSP program with equalisation support. For the start it is 
-recommended to use a pre-configured profile as the 4-way profile 
-(that can be also used for 1-,2- and 3-way speakers)
+Install a DSP program with equalisation support. For the start it is recommended to use a pre-configured profile as the 4-way profile (that can be also used for 1-,2- and 3-way speakers).
 
-```
-dsptoolkit install-profile https://raw.githubusercontent.com/hifiberry/hifiberry-dsp/master/sample_files/xml/4way-iir.xml 
+```bash
+dsptoolkit install-profile https://raw.githubusercontent.com/hifiberry/hifiberry-dsp/master/sample_files/xml/4way-iir.xml
 ```
 
 If you're using the DAC+ DSP, you should use another profile
-```
+
+```bash
 dsptoolkit install-profile https://raw.githubusercontent.com/hifiberry/hifiberry-dsp/master/sample_files/xml/dacdsp-default.xml
 ```
 
 If you want to create your own DSP profiles, have a look at our [guide](dspprofiles.md).
 
 ## Install REW
-Download and install REW on your PC. While it also runs on the 
-Raspberry Pi, we don't recommend to install and run it on the RPi. 
-The experience on the PC is much better as the program runs much 
-smoother on a PC than on the Raspberry Pi.
+
+Download and install REW on your PC. While it also runs on the Raspberry Pi, we don't recommend to install and run it on the RPi. The experience on the PC is much better as the program runs much smoother on a PC than on the Raspberry Pi.
 
 ## Connect and position the microphone
-If you use an USB measurement microphone (we recommend this), just 
-connect it to an USB port of your PC. If you use an XLR measurement 
-microphone, you will need an external microphone preamplifier to 
-connect it to an input of your sound card. 
-Don't try to use cheap electret microphones with the onboard sound 
-input from your PC. Most likely, linearity of both will be quite bad.
 
-The microphone should be positioned vertically at your listening 
-position. The height should be about the height of your head when 
-you sit at this position.  We recommend to use a microphone stand 
-to position the microphone.
+If you use an USB measurement microphone (we recommend this), just connect it to an USB port of your PC. If you use an XLR measurement microphone, you will need an external microphone preamplifier to connect it to an input of your sound card.
+Don't try to use cheap electret microphones with the onboard sound input from your PC. Most likely, linearity of both will be quite bad.
+
+The microphone should be positioned vertically at your listening position. The height should be about the height of your head when you sit at this position.  We recommend to use a microphone stand to position the microphone.
 
 ![microphone](img/mic.jpg)
 
-You might require an USB extension cable. Just note that for long 
-extensions you will need an active USB extension cable. You can 
-get these at your favourite computer shop.
+You might require an USB extension cable. Just note that for long extensions you will need an active USB extension cable. You can get these at your favorite computer shop.
 
 ## Connect the DSP board
 
-Connect the optical output of your PC or sound card to the optical 
-input of the HiFiBerry DSP/DAC or 4-channel amplifier.
+Connect the optical output of your PC or sound card to the optical input of the HiFiBerry DSP/DAC or 4-channel amplifier.
 
 ![TOSLink input](img/toslink-input.jpg)
 
 ## Configure REW
-Make sure, you select your measurement microphone as the input device 
-for REW in the setting dialogue. If your microphone comes with a 
-calibration file, you can configure it under the "Mic/Meter" tab.
+
+Make sure, you select your measurement microphone as the input device for REW in the setting dialogue. If your microphone comes with a calibration file, you can configure it under the "Mic/Meter" tab.
 
 ![REW preferences](img/rew-prefs.png)
 
-While you can configure the equalisation option later, we recommend 
-also to set the correct equalisation options. You should 
-select the Generic equalisation type:
+While you can configure the equalisation option later, we recommend also to set the correct equalisation options. You should select the Generic equalisation type:
 
 ![REW EQ preferences](img/rew-eq.png)
 
@@ -117,32 +91,21 @@ Now create a new measurement by clicking the Measure button.
 
 ![REW start measurement](img/rew-start.png)
 
-Make sure the frequency range is 20-20.000 Hz. During the measurement 
-REW shows you the headroom of the mesurement. Ideally it should be 
-between 3 and 10dB. If it's more, increase the volume using the 
-"Level (dbFS)" setting. If it is less than 3 or even 0dB, you need to 
-reduce the output level.
+Make sure the frequency range is 20-20.000 Hz. During the measurement REW shows you the headroom of the mesurement. Ideally it should be between 3 and 10dB. If it's more, increase the volume using the "Level (dbFS)" setting. If it is less than 3 or even 0dB, you need to reduce the output level.
 
-When the measurement is finished, REW will show you the 
-frequency response of your system:
+When the measurement is finished, REW will show you the frequency response of your system:
 
 ![REW frequency response](img/rew-fr.png)
 
-Note that this the the frequency response at the position of your 
-microphone. It will look differently if you move the microphone around. 
-You can do multiple measurements at multiple positions and calculate 
-an average to optimise the system for a broader range of listening 
-positions.
+Note that this the the frequency response at the position of your microphone. It will look differently if you move the microphone around. You can do multiple measurements at multiple positions and calculate an average to optimise the system for a broader range of listening positions.
 
-In this measurement you can see that it is not linear. The biggest 
-problem is the peak at 45Hz. This is looks like a so-called "room mode".  
+In this measurement you can see that it is not linear. The biggest problem is the peak at 45Hz. This is looks like a so-called "room mode".  
 In general there are 2 reasons for a non-linear frequency response:
 
 * Non-linearities of the speaker
 * Interactions with the room
 
-With a far-field measurement as we did it here, you can't distinguish 
-between both, but that's not a problem. REW will correct both.
+With a far-field measurement as we did it here, you can't distinguish between both, but that's not a problem. REW will correct both.
 
 ## Calculate optimisation filters
 
@@ -150,30 +113,15 @@ Select the optimisation dialog by clicking on the EQ button.
 
 ![REW optimisations](img/rew-opti.png)
 
-Under "Equalizer" select "Generic". Make sure speaker type is 
-"Full range".
+Under "Equalizer" select "Generic". Make sure speaker type is "Full range".
 
-Depending on your speakers, you can add a subsonic filter at a given 
-frequency using the "Bass limited" setting. This is especially helpful 
-with small speakers that can't If you're not sure what do do, 
-leave it at 40Hz.
+Depending on your speakers, you can add a subsonic filter at a given frequency using the "Bass limited" setting. This is especially helpful with small speakers that can't If you're not sure what do do, leave it at 40Hz.
 
-You might notice that the target isn't perfectly linear. There is a 
-slight increase of frequencies above 100Hz and a falling slope 
-starting at  1kHz. The reason for this is again room acoustics. As the 
-measurement took both direct and reflected sound into account, 
-we need to reduce the high frequencies a bit. These frequencies are 
-absorbed much more than lower frequencies. Therefore the measurement 
-will measure less reflected sound here. A falling slope compensates 
-for this effect.
+You might notice that the target isn't perfectly linear. There is a slight increase of frequencies above 100Hz and a falling slope starting at  1kHz. The reason for this is again room acoustics. As the measurement took both direct and reflected sound into account, we need to reduce the high frequencies a bit. These frequencies are absorbed much more than lower frequencies. Therefore the measurement will measure less reflected sound here. A falling slope compensates for this effect.
 
-First select the best matching "Target level" by clicking on 
-"Set target level". Sometimes this doesn't work perfectly. In this case
-just set the target level by yourself.
+First select the best matching "Target level" by clicking on "Set target level". Sometimes this doesn't work perfectly. In this case just set the target level by yourself.
 
-Then start the optimisation by clicking 
-"Match response to target". REW will now do it's "magic" and calculate 
-correction filters for your setup.
+Then start the optimisation by clicking "Match response to target". REW will now do it's "magic" and calculate correction filters for your setup.
 
 ![REW optimisations](img/rew-opti-result.png)
 
@@ -181,10 +129,7 @@ In the top-left diagram you will see the process, the correction filters and the
 
 ## Write the filters to the DSP
 
-Now you only have to transfer the correction filters to your 
-Raspberry Pi. First save these using the 
-"Export filter settings as text" menu item. REW will now create a 
-text file with the definition of the filters. It looks like this:
+Now you only have to transfer the correction filters to your Raspberry Pi. First save these using the "Export filter settings as text" menu item. REW will now create a text file with the definition of the filters. It looks like this:
 
 ```
 Filter Settings file
@@ -209,75 +154,65 @@ Filter 10: ON  PK       Fc   13666 Hz  Gain  -3.2 dB  Q  4.98
 Filter 11: ON  PK       Fc     706 Hz  Gain  -2.8 dB  Q  1.50
 Filter 12: ON  PK       Fc     675 Hz  Gain   3.8 dB  Q  5.00
 Filter 13: ON  PK       Fc     590 Hz  Gain   3.0 dB  Q  5.00
-Filter 14: ON  None   
-Filter 15: ON  None   
-Filter 16: ON  None   
-Filter 17: ON  None   
-Filter 18: ON  None   
-Filter 19: ON  None   
+Filter 14: ON  None
+Filter 15: ON  None
+Filter 16: ON  None
+Filter 17: ON  None
+Filter 18: ON  None
+Filter 19: ON  None
 Filter 20: ON  None
 ```
 
 Transfer this file to your Raspberry Pi (I recommend scp for this), e.g.
 
-```scp filters.txt pi@ip-of-your-pi```
+```bash
+scp filters.txt pi@ip-of-your-pi
+```
 
-Login to your Raspberry Pi and write these filters to the DSP using 
-the DSP Toolkit:
+Login to your Raspberry Pi and write these filters to the DSP using the DSP Toolkit:
 
-```dsptoolkit apply-rew-filters filters.txt```
+```bash
+dsptoolkit apply-rew-filters filters.txt
+```
 
 ## Run another measurement
 
-If you run another measurement now, the frequency response should 
-match the target response quite well. It won't be perfectly flat, 
-but that's fine.
+If you run another measurement now, the frequency response should the target response quite well. It won't be perfectly flat, but that's fine.
 
 ![REW frequency response](img/rew-fr2.png)
 
-
 ## Save the settings onto the DSP's EEPROM
 
-You just downloaded the settings to the DSP, but these will be lost 
-after a reboot. Therefore, you should save the DSP settings to the DSP.
+You just downloaded the settings to the DSP, but these will be lost after a reboot. Therefore, you should save the DSP settings to the DSP.
 
-```dsptoolkit store-filters```
-
+```bash
+dsptoolkit store-filters
+```
 
 ## Remove the filters
-Not happy with the results and you want to start with a new measurement 
-and another optimisation? You can remove all filter settings 
-using the DSP toolkit
 
-```dsptoolkit remove-iir-filters```
+Not happy with the results and you want to start with a new measurement and another optimisation? You can remove all filter settings using the DSP toolkit
+
+```bash
+dsptoolkit remove-iir-filters
+```
 
 ## Tips & tricks
 
 ### Run the optimization with a signal on both speakers
 
-If your speakers are identical, you should apply the same filters to 
-both speakers, especially if you use the full frequency range 
-(20-20.000Hz).
+If your speakers are identical, you should apply the same filters to both speakers, especially if you use the full frequency range (20-20.000Hz).
 
 ### Use equalisations wisely
 
-Most problems will be in the low frequencies (0-200Hz). If you're 
-speakers frequency response is reasonably flat (it doesn't need to 
-be perfect!), optimise only the low frequencies. Slight peaks of 2-3dB 
-in the frequency response are not a problem. You will see these with 
-practically every speaker in a normal listening environment. 
+Most problems will be in the low frequencies (0-200Hz). If you're speakers frequency response is reasonably flat (it doesn't need to be perfect!), optimise only the low frequencies. Slight peaks of 2-3dB in the frequency response are not a problem. You will see these with practically every speaker in a normal listening environment.
 
 Don't over-optimise!
 
 ### Low frequency vs. full range optimisations
 
-The following pictures shows 2 equalisation setting: One full-range 
-optimisation and one only in the range of 20-200Hz.
+The following pictures shows 2 equalisation setting: One full-range optimisation and one only in the range of 20-200Hz.
 
 ![REW optimisations](img/rew-opti-compare.png)
 
-Which one sound better? In both cases you will still hear the 
-"personality" of your speakers, but they will sound a bit different. 
-Try different profiles and listen to them. There is no simple right 
-or wrong - at the end your personal preference is important.
-
+Which one sound better? In both cases you will still hear the "personality" of your speakers, but they will sound a bit different. Try different profiles and listen to them. There is no simple right or wrong - at the end your personal preference is important.

--- a/doc/settingsfiles.md
+++ b/doc/settingsfiles.md
@@ -1,23 +1,22 @@
 Settings file format
 ====================
 
-A settings file is a text file that consists of lines of attribute:value 
-pairs. Attributes are register names defined in the profile metadata. 
-Values can be 
- - float values
- - integer values
- - decibel values (in format +xdb, -xdb)
- - percent values (for volume, will be converted to a -60db-0dB volume
-   control range)
- - IIR filter definitions (see above)
- 
- Example
- -------
- 
- Let's assume the following DSP profile:
- 
- ```
- <ROM>
+A settings file is a text file that consists of lines of attribute:value pairs. Attributes are register names defined in the profile metadata.  
+Values can be
+
+- float values
+- integer values
+- decibel values (in format +xdb, -xdb)
+- percent values (for volume, will be converted to a -60db-0dB volume control range)
+- IIR filter definitions (see above)
+
+Example
+-------
+
+Let's assume the following DSP profile:
+
+```xml
+<ROM>
   <beometa>
     <metadata type="IIR_L">37/80</metadata>
     <metadata type="IIR_R">117/80</metadata>
@@ -35,9 +34,9 @@ Values can be
     <metadata type="volumeLimitRegister">542</metadata>
   </beometa>
   ....
- </ROM>
- ```
- 
+</ROM>
+```
+
 A simple settings file for this DSP profile could look like this:
 
 ```
@@ -48,10 +47,10 @@ Applying these settings would set the the volumeLimit to -10dB.
 
 You can check this by running the command
 
+```bash
+dsptoolkit get-limit
 ```
- dsptoolkit get-limit
-```
- 
+
 A more complex file:
 
 ```
@@ -65,6 +64,4 @@ IIR_R2: vol: -3dB
 IIR_R3: vol: +0dB
 ```
 
-In this case, the mute setting would be ignored as no mute attribute
-is available in the DSP profile. 
-
+In this case, the mute setting would be ignored as no mute attribute is available in the DSP profile.


### PR DESCRIPTION
I linted the markdown files in the doc folder so they can be read more easily when rendered on the GitHub website. No content or meaning was changed, just the formatting to improve readability.

- introduced code blocks with language identifier where reasonable
- set commands to monospaced font
- removed random line breaks within sentences
- some missing punctuation & typos

Feel free to ask about any specific edits in particular.