### PR TITLE
Implemented volume adjustment feature

### DIFF
--- a/doc/dsptoolkit.md
+++ b/doc/dsptoolkit.md
@@ -21,6 +21,12 @@ The following commands are supported. Note that some command need specific param
   For negative db values, you need to prefix these with `--`, e.g.  
     `dsptoolkit set-volume -- -3db`
 
+* `adjust-volume volume`
+
+  adjust the volume. Volume adjustment values can be defined just as for `set-volume`. With `adjust-volume`, the current volume is adjusted by the chosen amount, instead of setting it to a fixed level.
+  For negative db values, you need to prefix these with `--`, e.g.  
+    `dsptoolkit adjust-volume -- -3db`
+
 * `get-volume`
 
   gets the current setting of the volume control register.


### PR DESCRIPTION
Currently, there are only the command-line options `get-volume` and `set-volume`. I wanted to change the volume on a DSP volume register incrementally, for example with a remote control.

Thus, this pull request implements a new feature: `adjust-volume`.
It uses the same types of inputs as `set-volume`, but performs a relative volume adjustment. Maximum and minimum volumes are bounded for safety reasons [0, 1]. 

Documentation was also added. The code was fully tested with a local installation.