### PR TITLE
Add `asound` headers in Debian install script

### DIFF
--- a/install-dsptoolkit
+++ b/install-dsptoolkit
@@ -1,6 +1,6 @@
 #!/bin/sh
 sudo apt-get update
-sudo apt-get install -y python3-pip libxslt1-dev libxml2-dev zlib1g-dev python3-lxml python-lxml libxml2-dev libxslt-dev python-dev
+sudo apt-get install -y python3-pip libasound2-dev libxslt1-dev libxml2-dev zlib1g-dev python3-lxml python-lxml libxml2-dev libxslt-dev python-dev
 sudo pip3 install --upgrade hifiberrydsp
 
 for i in sigmatcp; do


### PR DESCRIPTION
This is the one change I needed to use my HifiBerry DAC+ working on a fresh install of the new* 64-bit Raspberry Pi OS.

\* Well, about 6 months old. I'm surprised no one else has reported this yet.