### PR TITLE
Fix sample rate metadata

### DIFF
--- a/sample_files/xml/dacdsp-v12-1.xml
+++ b/sample_files/xml/dacdsp-v12-1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" standalone="no"?>
 <ROM IC="ADAU1451" IC_Address="1" Address_byte_length="2">
 <beometa>
-	<metadata type="sampleRate">48000</metadata>
+	<metadata type="samplerate">48000</metadata>
 	<metadata type="profileName">DAC+ DSP Universal</metadata>
 	<metadata type="profileVersion">12-1</metadata>
 	<metadata type="programID">dacdsp</metadata>

--- a/sample_files/xml/generic192.xml
+++ b/sample_files/xml/generic192.xml
@@ -32,7 +32,7 @@
 		<metadata type="delay2">634</metadata>
 		<metadata type="delay3">635</metadata>
 		<metadata type="delay4">636</metadata>
-		<metadata type="sampleRate">192000</metadata>
+		<metadata type="samplerate">192000</metadata>
 		<metadata type="customFilterRegisterBankLeft">132/80</metadata>
 		<metadata type="customFilterRegisterBankRight">52/80</metadata>
 		<metadata type="toneControlLeftRegisters">212/50</metadata>

--- a/sample_files/xml/generic96.xml
+++ b/sample_files/xml/generic96.xml
@@ -3,7 +3,7 @@
 	<beometa>
                 <metadata type="profileName">Generic 96kHz</metadata>
                 <metadata type="profileVersion">20191121</metadata>
-                <metadata type="sampleRate">96000</metadata>
+                <metadata type="samplerate">96000</metadata>
                 <metadata type="checksum">AEE5921C33D71C02C9D14679496B20B3</metadata>
 		<metadata type="volumeLimitPiRegister">4680</metadata>
 		<metadata type="volumeLimitSPDIFRegister">4682</metadata>


### PR DESCRIPTION
Changing the capitalization of these "sampleRate" metadata entries to match the [correct attribute](https://github.com/hifiberry/hifiberry-dsp/blob/39755280191c9cbe066288e3dfb34710c7a9db10/hifiberrydsp/parser/xmlprofile.py#L57) should solve issue #43. Will also open a PR for affected xml files in hifiberry-os.