### PR TITLE
updated invalid filter-clearing parameter

### DIFF
--- a/doc/rew-basics.md
+++ b/doc/rew-basics.md
@@ -194,7 +194,7 @@ dsptoolkit store-filters
 Not happy with the results and you want to start with a new measurement and another optimisation? You can remove all filter settings using the DSP toolkit
 
 ```bash
-dsptoolkit remove-iir-filters
+dsptoolkit clear-iir-filters
 ```
 
 ## Tips & tricks


### PR DESCRIPTION
dsptoolkit argument `remove-iir-filters` does not exist and should be `clear-iir-filters`