### PR TITLE
using pip for install

### DIFF
--- a/install-dsptoolkit
+++ b/install-dsptoolkit
@@ -7,8 +7,7 @@ done
 cd
 git clone https://github.com/hifiberry/hifiberry-dsp
 cd hifiberry-dsp
-sudo python3 ./setup.py install 
-
+sudo python3 -m pip install . --break-system-packages
 for i in sigmatcp; do
  sudo systemctl stop $i
  sudo systemctl disable $i


### PR DESCRIPTION
I noticed 
`python3 ./setup.py install` 
does not install latest changes.
Also it is deprecated.
https://packaging.python.org/en/latest/discussions/setup-py-deprecated/#setup-py-deprecated
I changed install scripts to use 
`pip install .`
instead.